### PR TITLE
persist config as dotenv file

### DIFF
--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -3,17 +3,25 @@ set -e
 
 echo ">>>>>>>>>>>>>> START CUSTOM ENTRYPOINT SCRIPT <<<<<<<<<<<<<<<<< "
 
+if [[ -f /data/.env ]]; then
+
 # set runtime env. vars on the fly
-export APP_ENV=prod
-export APP_DATABASE_NAME=${ARTIFAKT_MYSQL_DATABASE_NAME:-changeme}
-export APP_DATABASE_USER=${ARTIFAKT_MYSQL_USER:-changeme}
-export APP_DATABASE_PASSWORD=${ARTIFAKT_MYSQL_PASSWORD:-changeme}
-export APP_DATABASE_HOST=${ARTIFAKT_MYSQL_HOST:-mysql}
-export APP_DATABASE_PORT=${ARTIFAKT_MYSQL_PORT:-3306}
+cat << EOF > /data/.env
+APP_ENV=prod
+APP_DATABASE_NAME=${ARTIFAKT_MYSQL_DATABASE_NAME:-changeme}
+APP_DATABASE_USER=${ARTIFAKT_MYSQL_USER:-changeme}
+APP_DATABASE_PASSWORD=${ARTIFAKT_MYSQL_PASSWORD:-changeme}
+APP_DATABASE_HOST=${ARTIFAKT_MYSQL_HOST:-mysql}
+APP_DATABASE_PORT=${ARTIFAKT_MYSQL_PORT:-3306}
+DATABASE_URL=mysql://$ARTIFAKT_MYSQL_USER:$ARTIFAKT_MYSQL_PASSWORD@$ARTIFAKT_MYSQL_HOST:$ARTIFAKT_MYSQL_PORT/$ARTIFAKT_MYSQL_DATABASE_NAME
+EOF
 
-export DATABASE_URL=mysql://$ARTIFAKT_MYSQL_USER:$ARTIFAKT_MYSQL_PASSWORD@$ARTIFAKT_MYSQL_HOST:$ARTIFAKT_MYSQL_PORT/$ARTIFAKT_MYSQL_DATABASE_NAME
+fi
 
-echo "Creating all symbolic links"
+#echo "Creating the link for .env file"
+ln -snf /data/.env /var/www/html/
+
+ echo "Creating all symbolic links"
 PERSISTENT_FOLDER_LIST=("custom/plugins" "files" "config/jwt" "public/theme" "public/media" "public/thumbnail" "public/bundles" "public/sitemap")
 for persistent_folder in ${PERSISTENT_FOLDER_LIST[@]}; do
   echo Mount $persistent_folder directory
@@ -23,8 +31,6 @@ for persistent_folder in ${PERSISTENT_FOLDER_LIST[@]}; do
     chown -h www-data:www-data /var/www/html/$persistent_folder /data/$persistent_folder
 done
 
-#echo "Creating the link for .env file"
-#ln -snf /data/.env /var/www/html/
 ln -snf /data/.uniqueid.txt /var/www/html/
 
 echo "End of symbolic links creation"

--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -5,19 +5,19 @@ echo ">>>>>>>>>>>>>> START CUSTOM ENTRYPOINT SCRIPT <<<<<<<<<<<<<<<<< "
 
 if [[ ! -f "/data/.env" ]]; then
 
-# set runtime env. vars on the fly
-cat << EOF > /data/.env
-APP_ENV=prod
-APP_DATABASE_NAME=${ARTIFAKT_MYSQL_DATABASE_NAME:-changeme}
-APP_DATABASE_USER=${ARTIFAKT_MYSQL_USER:-changeme}
-APP_DATABASE_PASSWORD=${ARTIFAKT_MYSQL_PASSWORD:-changeme}
-APP_DATABASE_HOST=${ARTIFAKT_MYSQL_HOST:-mysql}
-APP_DATABASE_PORT=${ARTIFAKT_MYSQL_PORT:-3306}
-DATABASE_URL=mysql://$ARTIFAKT_MYSQL_USER:$ARTIFAKT_MYSQL_PASSWORD@$ARTIFAKT_MYSQL_HOST:$ARTIFAKT_MYSQL_PORT/$ARTIFAKT_MYSQL_DATABASE_NAME
+  # set runtime env. vars on the fly
+  cat << EOF > /data/.env
+  APP_ENV=prod
+  APP_DATABASE_NAME=${ARTIFAKT_MYSQL_DATABASE_NAME:-changeme}
+  APP_DATABASE_USER=${ARTIFAKT_MYSQL_USER:-changeme}
+  APP_DATABASE_PASSWORD=${ARTIFAKT_MYSQL_PASSWORD:-changeme}
+  APP_DATABASE_HOST=${ARTIFAKT_MYSQL_HOST:-mysql}
+  APP_DATABASE_PORT=${ARTIFAKT_MYSQL_PORT:-3306}
+  DATABASE_URL=mysql://$ARTIFAKT_MYSQL_USER:$ARTIFAKT_MYSQL_PASSWORD@$ARTIFAKT_MYSQL_HOST:$ARTIFAKT_MYSQL_PORT/$ARTIFAKT_MYSQL_DATABASE_NAME
 EOF
 
-echo "Adding symlink for .env file"
-ln -snf /data/.env /var/www/html/
+  echo "Adding symlink for .env file"
+  ln -snf /data/.env /var/www/html/
 
 fi
 

--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 echo ">>>>>>>>>>>>>> START CUSTOM ENTRYPOINT SCRIPT <<<<<<<<<<<<<<<<< "
 
-if [[ -f /data/.env ]]; then
+if [[ -f "/data/.env" ]]; then
 
 # set runtime env. vars on the fly
 cat << EOF > /data/.env

--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 echo ">>>>>>>>>>>>>> START CUSTOM ENTRYPOINT SCRIPT <<<<<<<<<<<<<<<<< "
 
-if [[ -f "/data/.env" ]]; then
+if [[ ! -f "/data/.env" ]]; then
 
 # set runtime env. vars on the fly
 cat << EOF > /data/.env
@@ -16,10 +16,10 @@ APP_DATABASE_PORT=${ARTIFAKT_MYSQL_PORT:-3306}
 DATABASE_URL=mysql://$ARTIFAKT_MYSQL_USER:$ARTIFAKT_MYSQL_PASSWORD@$ARTIFAKT_MYSQL_HOST:$ARTIFAKT_MYSQL_PORT/$ARTIFAKT_MYSQL_DATABASE_NAME
 EOF
 
-fi
-
 #echo "Creating the link for .env file"
 ln -snf /data/.env /var/www/html/
+
+fi
 
  echo "Creating all symbolic links"
 PERSISTENT_FOLDER_LIST=("custom/plugins" "files" "config/jwt" "public/theme" "public/media" "public/thumbnail" "public/bundles" "public/sitemap")

--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -21,21 +21,6 @@ ln -snf /data/.env /var/www/html/
 
 fi
 
- echo "Creating all symbolic links"
-PERSISTENT_FOLDER_LIST=("custom/plugins" "files" "config/jwt" "public/theme" "public/media" "public/thumbnail" "public/bundles" "public/sitemap")
-for persistent_folder in ${PERSISTENT_FOLDER_LIST[@]}; do
-  echo Mount $persistent_folder directory
-  rm -rf /var/www/html/$persistent_folder && \
-    mkdir -p /data/$persistent_folder && \
-    ln -sfn /data/$persistent_folder /var/www/html/$persistent_folder && \
-    chown -h www-data:www-data /var/www/html/$persistent_folder /data/$persistent_folder
-done
-
-echo "Adding symlink for uniqueid file"
-ln -snf /data/.uniqueid.txt /var/www/html/
-
-echo "End of symbolic links creation"
-
 until nc -z -v -w30 $ARTIFAKT_MYSQL_HOST $ARTIFAKT_MYSQL_PORT
 do
   echo "Waiting for database connection on $ARTIFAKT_MYSQL_HOST:$ARTIFAKT_MYSQL_PORT"

--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+unset APP_ENV
+unset APP_DEBUG
+
 echo ">>>>>>>>>>>>>> START CUSTOM ENTRYPOINT SCRIPT <<<<<<<<<<<<<<<<< "
 
 if [[ ! -f "/data/.env" ]]; then

--- a/.artifakt/entrypoint.sh
+++ b/.artifakt/entrypoint.sh
@@ -16,7 +16,7 @@ APP_DATABASE_PORT=${ARTIFAKT_MYSQL_PORT:-3306}
 DATABASE_URL=mysql://$ARTIFAKT_MYSQL_USER:$ARTIFAKT_MYSQL_PASSWORD@$ARTIFAKT_MYSQL_HOST:$ARTIFAKT_MYSQL_PORT/$ARTIFAKT_MYSQL_DATABASE_NAME
 EOF
 
-#echo "Creating the link for .env file"
+echo "Adding symlink for .env file"
 ln -snf /data/.env /var/www/html/
 
 fi
@@ -31,6 +31,7 @@ for persistent_folder in ${PERSISTENT_FOLDER_LIST[@]}; do
     chown -h www-data:www-data /var/www/html/$persistent_folder /data/$persistent_folder
 done
 
+echo "Adding symlink for uniqueid file"
 ln -snf /data/.uniqueid.txt /var/www/html/
 
 echo "End of symbolic links creation"
@@ -64,7 +65,7 @@ if [ $is_installed -eq 1 ]; then
   cp public/.htaccess.dist public/.htaccess
 fi
 
-#echo "Changing owner of html"
+echo "Changing owner of html to www-data"
 chown -R www-data:www-data /var/www/html /data
 
 echo ">>>>>>>>>>>>>> END CUSTOM ENTRYPOINT SCRIPT <<<<<<<<<<<<<<<<< "

--- a/.artifakt/shopware/rootfs/fix-install.php
+++ b/.artifakt/shopware/rootfs/fix-install.php
@@ -9,7 +9,9 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\Exception\LanguageNotFoundException;
 
-$params = parse_url(getenv('DATABASE_URL'));
+$dotenv=parse_ini_file('/var/www/html/.env', false, INI_SCANNER_RAW);
+$params = parse_url($dotenv['DATABASE_URL']);
+
 $dbName = substr($params['path'], 1);
 
 $dsnWithoutDb = sprintf(


### PR DESCRIPTION
This PR replaces env vars at entrypoint by a dotenv file, to be interpreted by the underlying Symfony framework.